### PR TITLE
add authstore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "^15.4.1",
-        "react-router-dom": "^7.4.0",
         "react-icons": "^5.5.0",
+        "react-router-dom": "^7.4.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {

--- a/src/store/AuthStore/useAuthStore.js
+++ b/src/store/AuthStore/useAuthStore.js
@@ -1,0 +1,84 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { login, logout } from "../../mocks/mockAuthApi";
+
+/**
+ * User object:
+ * @typedef {Object} User
+ * @property {number} id - The user's ID
+ * @property {string} name - The user's name
+ * @property {string} email - The user's email
+ * @property {string} avatar - The user's avatar URL
+ */
+
+/**
+ * Initial state for the auth store
+ * Use this to initialize the store with the initial state
+ * @type {{
+ * user: User | null,
+ * token: string | null,
+ * isAuthenticated: boolean,
+ * error: string | null,
+ * }}
+ */
+
+const initialState = {
+  user: null,
+  token: null,
+  isAuthenticated: false,
+  error: null,
+};
+
+/**
+ * Store for managing authentication state
+ *@property {User | null} user - The user object
+ *@property {string | null} token - The JWT token
+ *@property {boolean} isAuthenticated - Whether the user is authenticated
+ *@property {string | null} error - The error message
+ *@property {function} login - Logs in the user
+ *@property {function} logout - Logs out the user
+ *@example
+ * const login = useAuthStore((state) => state.login);
+ * authStore.login("testuser@example.com", "password123");
+ */
+
+const useAuthStore = create(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      login: async (email, password) => {
+        try {
+          const { token, user } = await login(email, password);
+          set({ token, user, isAuthenticated: true });
+        } catch (error) {
+          set({
+            error:
+              error.message || "Something went wrong with the login process",
+          });
+        }
+      },
+
+      logout: async () => {
+        try {
+          const { message } = await logout();
+          // Just to simulate a successful logout
+          // Remove this console.log when we have a real logout functionality
+          console.log(message);
+          set({ ...initialState });
+          localStorage.removeItem("auth");
+        } catch (error) {
+          set({
+            error:
+              error.message || "Something went wrong with the logout process",
+          });
+        }
+      },
+    }),
+    {
+      name: "auth",
+    }
+  )
+);
+
+export default useAuthStore;


### PR DESCRIPTION
### What does this PR do?
Adds a global authentication store using Zustand with persist middleware, simulating third-party authentication (e.g., Netlify/Google) via a mock API.

### Description of Task to be completed?
- Created /store/AuthStore/useAuthStore.js
- Implemented authentication state using Zustand (user, token, isAuthenticated, error)
- Integrated login and logout actions calling a mock API
- Added zustand/persist to store auth data in localStorage
- Cleaned up localStorage on logout for a complete session reset
- Added JSDoc comments to document purpose, types, and usage of the store

### How should this be manually tested?
- Start the application.
- Try logging in with the test credentials (email: testuser@example.com, password: password123)
- Check that the auth state updates (isAuthenticated becomes true, token and user are set).
- Logout and verify that the store resets to the initial state, localStorage key auth is removed, test invalid login to ensure error handling works.

### Any background context you want to provide?
This implementation is meant for development/testing purposes only.
The mock API simulates behavior of third-party login services (e.g., Google, Netlify), and helps verify how Zustand handles authentication logic globally before integrating a real backend.