### PR TITLE
feat: add employees file in files collection

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -33,6 +33,59 @@ collections:
         fields:
           - { label: 'Title', name: 'title', widget: 'string' }
 
+      - file: 'content/employees/employees.md'
+        name: 'employees'
+        label: 'Employees/team'
+        fields:
+          - label: 'Employees'
+            name: 'employees'
+            widget: 'list'
+            allow_add: true
+            collapsed: true
+            sortable: true
+            fields:
+              - {
+                  label: 'Name',
+                  name: 'name',
+                  widget: 'string',
+                  required: true,
+                }
+              - {
+                  label: 'Display order',
+                  name: 'order',
+                  widget: 'number',
+                  required: false,
+                }
+              - {
+                  label: 'Image',
+                  name: 'image',
+                  widget: 'image',
+                  required: true,
+                }
+              - {
+                  label: 'Bio',
+                  name: 'bio',
+                  widget: 'markdown',
+                  required: true,
+                }
+              - {
+                  label: 'Job Title',
+                  name: 'job_title',
+                  widget: 'string',
+                  required: true,
+                }
+              - label: 'Charity Roles'
+                name: 'charity_roles'
+                widget: 'list'
+                field: { label: 'Role', name: 'role', widget: 'string' }
+                required: false
+              - {
+                  label: 'Email',
+                  name: 'email',
+                  widget: 'string',
+                  required: false,
+                }
+
       - file: 'content/news/news.md'
         name: 'news-and-events'
         label: 'News and Events'
@@ -135,5 +188,5 @@ collections:
           label: 'Tags',
           name: 'tags',
           widget: 'list',
-          field: { widget: 'string' },
+          field: { name: 'tag', widget: 'string' },
         }


### PR DESCRIPTION
This PR adds a Employees file in the files collection. 
It is a list widget, so you can add multiple employees, with name, image, job title (i.e. "Violin Teacher", role within charity (i.e. "MMF Co-founder"), bio, email, and display order. 

Also added "name: tag" property to Blog Tags field, to resolve an error there "name property required". 

 Closes #888 and #889 
