### PR TITLE
800 configure backend cms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .qodo
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm run build"
-  publish = "build"
+  publish = "dist"
 
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = "build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,10 +1,9 @@
 backend:
-  name: github
-  repo: NoroffFEU/musikkforandrerliv.no
-  branch: 719-Decap-CMS # Change to main ???
-  local_backend: true
+  name: git-gateway
+  branch: 719-Decap-CMS # Change to main later?
 
-media_folder: 'public/assets/images'
+media_folder: 'public/uploads' # Where uploaded files will be stored
+public_folder: '/uploads' # Path to access uploaded files
 
 collections:
   - name: 'pages'
@@ -135,5 +134,5 @@ collections:
           label: 'Tags',
           name: 'tags',
           widget: 'list',
-          field: { widget: 'string' },
+          field: { name: 'tag', widget: 'string' },
         }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MMf-Decap</title>
-    <link
-      href="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.css"
-      rel="stylesheet"
-    />
+    <title>MMF Decap CMS</title>
   </head>
   <body>
-    <h1>i am working yo</h1>
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script
+      src="https://unpkg.com/netlify-cms@latest/dist/netlify-cms.js"
+      onload="CMS.init()"
+    ></script>
   </body>
 </html>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from 'react';
+
 import { Route, Routes, useLocation } from 'react-router-dom';
-import MainLayout from '../components/MainLayout.jsx';
+
 import ErrorBoundary from '../components/ErrorBoundary.jsx';
 import LoadingSpinner from '../components/LoadingSpinner.jsx';
-import { useEffect, useState } from 'react';
+import MainLayout from '../components/MainLayout.jsx';
 import About from '../pages/About';
 import Contact from '../pages/Contact';
 import Home from '../pages/Home';
@@ -21,25 +23,24 @@ const AppRoutes = () => {
     }, 200);
 
     return () => clearTimeout(timer);
-    }, [location]);
+  }, [location]);
 
   return (
-      <ErrorBoundary>
-        {loading ? ( 
-          <LoadingSpinner /> 
-        ) : ( 
-          <Routes>
-            <Route path="/" element={<MainLayout />}>
-              <Route path="/" element={<Home />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/contact" element={<Contact />} />
-              <Route path="/test-translations" element={<TestTranslations />} />
-              <Route path="*" element={<NotFound />} />
-            </Route>
-          </Routes>
-        )}
-      </ErrorBoundary>
-
+    <ErrorBoundary>
+      {loading ? (
+        <LoadingSpinner />
+      ) : (
+        <Routes>
+          <Route path="/" element={<MainLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/test-translations" element={<TestTranslations />} />
+            {/* <Route path="*" element={<NotFound />} />*/}
+          </Route>
+        </Routes>
+      )}
+    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
This PR implements backend solution suggested by Abi, where site is deployed on Netlify and using git-gateway.

Because we’re transitioning to Netlify Identity with Git Gateway instead of GitHub OAuth, the CMS login flow only works on the main production domain, i.e. merging to the production branch "develop". I have tried Netlify preview deployments, but they don’t support the invite token confirmation flow, so I haven't been able to fully test login or content editing from a PR preview.

The only solution I've found to complete the setup, is that we need to merge to "develop" for deployment, so when we invite users, they can confirm their account. Once confirmed, they can log in and use the CMS locally or in preview environments.