### PR TITLE
Remove Welcome to MMF project section from the codebase

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,12 +1,14 @@
-import React, { lazy, Suspense } from "react";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
+import React, { Suspense, lazy } from 'react';
 
-import ErrorBoundary from "../components/ErrorBoundary.jsx";
-import { HeroSection } from "../components/homePage/heroSection";
-import WorkSection from "../components/homePage/workSection";
-import "../i18n";
-import heart from "/assets/images/svgs/heart.svg";
+import { Link } from 'react-router-dom';
+
+import { useTranslation } from 'react-i18next';
+
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
+import { HeroSection } from '../components/homePage/heroSection';
+import WorkSection from '../components/homePage/workSection';
+import '../i18n';
+import heart from '/assets/images/svgs/heart.svg';
 
 // Safe lazy loader for components
 const safeLazy = (importFunc) =>
@@ -14,21 +16,33 @@ const safeLazy = (importFunc) =>
     importFunc()
       .then((mod) => {
         const comp = mod.default || mod[Object.keys(mod)[0]];
-        if (!comp) throw new Error("Missing export in component");
+        if (!comp) throw new Error('Missing export in component');
         return { default: comp };
       })
       .catch((err) => {
-        console.warn("Component not ready yet:", err);
+        console.warn('Component not ready yet:', err);
         return { default: () => null };
-      })
+      }),
   );
 
-const HistorySection = safeLazy(() => import("../components/homePage/historySection"));
-const StaffSection = safeLazy(() => import("../components/homePage/staffSection"));
-const VolunteerSection = safeLazy(() => import("../components/homePage/volunteerSection"));
-const SupportSection = safeLazy(() => import("../components/homePage/supportSection"));
-const GallerySection = safeLazy(() => import("../components/homePage/gallerySection"));
-const CalenderSection = safeLazy(() => import("../components/homePage/calenderSection"));
+const HistorySection = safeLazy(
+  () => import('../components/homePage/historySection'),
+);
+const StaffSection = safeLazy(
+  () => import('../components/homePage/staffSection'),
+);
+const VolunteerSection = safeLazy(
+  () => import('../components/homePage/volunteerSection'),
+);
+const SupportSection = safeLazy(
+  () => import('../components/homePage/supportSection'),
+);
+const GallerySection = safeLazy(
+  () => import('../components/homePage/gallerySection'),
+);
+const CalenderSection = safeLazy(
+  () => import('../components/homePage/calenderSection'),
+);
 
 const Home = () => {
   const { t } = useTranslation();
@@ -36,21 +50,6 @@ const Home = () => {
   return (
     <ErrorBoundary>
       <div>
-        <div className="h-screen w-full flex flex-col justify-center items-center">
-          <h1 className="text-2xl font-extrabold">
-            {t("Welcome to MMF project")}{" "}
-            <img className="inline bg-red-600" src={heart} alt="heart icon" />
-          </h1>
-          <div className="flex items-center justify-center h-96 px-4 w-full">
-            <Link
-              to="/test-translations"
-              className="px-4 py-2 bg-blue-500 text-white rounded"
-            >
-              Test Translations
-            </Link>
-          </div>
-        </div>
-
         <HeroSection />
 
         <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
Remove Welcome to MMF project section from the homepage.
Layout remains intact and there is no broken style after removal.