### PR TITLE
fix-read-more-links

### DIFF
--- a/src/components/homePage/historySection.jsx
+++ b/src/components/homePage/historySection.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import data from '../../data/landing-page-content.json';
+import {Link} from 'react-router-dom';
 
 export function HistorySection() {
   const { image, title, content } = data.history;
@@ -72,9 +73,9 @@ export function HistorySection() {
           className="mx-auto w-full h-auto object-cover"
         />
 
-        <button className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
+        <Link to="/about" className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
           READ MORE
-        </button>
+        </Link>
       </div>
 
       <button

--- a/src/components/homePage/supportSection.jsx
+++ b/src/components/homePage/supportSection.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { Link } from 'react-router-dom';
 import { IoIosArrowForward } from 'react-icons/io';
 
 import supportData from '../../data/support.json';
@@ -31,9 +31,9 @@ const SupportSection = () => {
             {supportData.content}
           </p>
           <div className="hidden gap-[20px] sm:flex sm:flex-row md:flex-col lg:flex-row">
-            <button className="inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer whitespace-nowrap">
+            <Link to="/placeholder" className="inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer whitespace-nowrap">
               READ MORE
-            </button>
+            </Link>
             <button className="inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer text-white bg-[var(--color-sunset-red)] border-[var(--color-sunset-red)]">
               DONATE
             </button>

--- a/src/components/homePage/volunteerSection.jsx
+++ b/src/components/homePage/volunteerSection.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { IoIosArrowForward } from 'react-icons/io';
 
 import content from '../../data/landing-page-content.json';
+
 
 const VolunteerSection = () => {
   const volunteerContent = content.volunteer;
@@ -28,9 +30,9 @@ const VolunteerSection = () => {
               {paragraph}
             </p>
           ))}
-          <button className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
+          <Link to="/placeholder" className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
             READ MORE
-          </button>
+          </Link>
         </div>
         <div className="w-full md:w-1/2 md:h-full flex items-center justify-center">
           <img

--- a/src/components/homePage/workSection.jsx
+++ b/src/components/homePage/workSection.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { IoIosArrowForward } from 'react-icons/io';
 
 import data from '../../data/landing-page-content.json';
+
 
 export default function WorkSection() {
   const { image, title, content } = data.work;
@@ -31,9 +33,9 @@ export default function WorkSection() {
           <p className="[font-family:var(--font-sans)] text-sm sm:text-lg max-w-[462px] text-[#363732]">
             {content}
           </p>
-          <button className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
-            READ MORE
-          </button>
+          <Link to="/work" className="hidden sm:inline-block w-fit py-4 px-[30px] border rounded-[9px] [font-family:var(--font-sans) ] font-semibold md:text-2xl cursor-pointer">
+          READ MORE
+        </Link>
         </div>
       </div>
     </section>

--- a/src/pages/PlaceHolder.jsx
+++ b/src/pages/PlaceHolder.jsx
@@ -1,0 +1,14 @@
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
+
+function PlaceHolder() {
+  return (
+    <ErrorBoundary>
+      <div className="h-screen w-full flex justify-center items-center flex-col">
+        <h1 className="text-2xl font-extrabold">Coming Soon</h1>
+        <h2>This page is under construction. We're preparing something great — stay tuned!</h2>
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+export default PlaceHolder;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -10,7 +10,7 @@ import News from '../pages/News';
 import NotFound from '../pages/NotFound';
 import TestTranslations from '../pages/TestTranslations';
 import OurWork from '../pages/OurWork';
-import Placeholder from '../pages/Placeholder';
+import Placeholder from '../pages/PlaceHolder';
 
 const AppRoutes = () => {
   const [loading, setLoading] = useState(false);

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -10,6 +10,7 @@ import News from '../pages/News';
 import NotFound from '../pages/NotFound';
 import TestTranslations from '../pages/TestTranslations';
 import OurWork from '../pages/OurWork';
+import Placeholder from '../pages/Placeholder';
 
 const AppRoutes = () => {
   const [loading, setLoading] = useState(false);
@@ -39,6 +40,7 @@ const AppRoutes = () => {
               <Route path="/work" element={<OurWork />} />
               <Route path="/test-translations" element={<TestTranslations />} />
               <Route path="*" element={<NotFound />} />
+              <Route path="/placeholder" element={<Placeholder/>} />
             </Route>
           </Routes>
         )}


### PR DESCRIPTION
- Each button now routes to its corresponding page using react-router-dom by Link
- If a route/page isn’t ready yet, the button links to a shared "/placeholder" placeholder page
- Placeholder page uses the same structure/layout as existing pages (About, Our Work)

- Ran npm run dev — no errors
- Clicked all “Read More” links and confirmed correct navigation

