### PR TITLE
Link to news post page

### DIFF
--- a/src/components/LatestNews.jsx
+++ b/src/components/LatestNews.jsx
@@ -1,7 +1,23 @@
 import React from "react";
 import ReadMore from "./Readmore";
+import {Link} from "react-router-dom";
 
-const LatestNews = ({ newsPost, writtenBy, location, date, title, content, image }) => {
+
+const LatestNews = ({ id, newsPost, writtenBy, location, date, title, content, image }) => {
+  const handleClick = () => {
+    const newsPostData = {
+      newsPost,
+      writtenBy,
+      location,
+      date,
+      title,
+      content,
+      image
+    };
+    sessionStorage.setItem("newsPostData", JSON.stringify(newsPostData));
+    console.log('saved to sessionStorage:', newsPostData);
+  };
+   
   return (
     <article className="bg-white overflow-hidden mb-12">
       <div className="flex flex-col md:flex-row">
@@ -14,7 +30,11 @@ const LatestNews = ({ newsPost, writtenBy, location, date, title, content, image
         </div>
         <div className="w-full md:w-2/4 md:px-6">
             <p className="text-gray-500 uppercase md:mt-0 sm:mt-10">{newsPost}</p>
+            <Link to={`/news-post`} className="no-underline"
+            onClick={handleClick}
+            >
             <h3 className="text-4xl font-semibold mt-8">{title}</h3>
+            </Link>
             <div className="flex flex-col sm:flex-row justify-between mt-8">
               <p className="text-gray-500 text-sm capitalize">{writtenBy}</p>
               <div className="flex flex-col sm:flex-row sm:gap-2">

--- a/src/components/LatestNews.jsx
+++ b/src/components/LatestNews.jsx
@@ -15,7 +15,7 @@ const LatestNews = ({ id, newsPost, writtenBy, location, date, title, content, i
       image
     };
     sessionStorage.setItem("newsPostData", JSON.stringify(newsPostData));
-    console.log('saved to sessionStorage:', newsPostData);
+    console.log('saved to sessionStorage:', newsPostData); // Debugging line
   };
    
   return (

--- a/src/pages/NewsPost.jsx
+++ b/src/pages/NewsPost.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 function NewsPost() {
+  
   return (
     <div className="w-full max-w-[1000px] mx-auto mt-[100px] pb-[60px] px-4 font-montserrat">
       {/* Breadcrumb Navigation */}


### PR DESCRIPTION
- Created a <Link> from each news post to /news-post
- Used sessionStorage to save the clicked post’s data
- Confirmed saving via console.log() and browser DevTools
- Navigating to /news-post is working correctly


![Screenshot 2025-03-31 230352](https://github.com/user-attachments/assets/2f6a9219-d9bc-44c2-ba8e-fb1173ce3d6a)
