### PR TITLE
adjust height offset in HeroBannerNav and refine padding/margin in ca…

### DIFF
--- a/src/components/ourWorkPage/HeroBannerNav.jsx
+++ b/src/components/ourWorkPage/HeroBannerNav.jsx
@@ -25,7 +25,7 @@ export default function HeroBannerNav() {
       const sectionPosition =
         section.getBoundingClientRect().top + window.scrollY; // absolute position for section
       const windowHeight = window.innerHeight;
-      const offset = windowHeight * 0.2; // 20% height offset
+      const offset = windowHeight * 0.25; // 20% height offset
       const scrollPosition = sectionPosition - offset; // adjusting position to offset
 
       window.scrollTo({

--- a/src/components/ourWorkPage/categorySection.jsx
+++ b/src/components/ourWorkPage/categorySection.jsx
@@ -19,7 +19,7 @@ const CategorySection = () => {
   };
 
   return (
-    <section className="container mx-auto max-w-6xl px-4 py-8">
+    <section className="container mx-auto max-w-6xl px-8 md:px-4 py-8">
       <div className="space-y-16">
         {sections.map((section, index) => (
           <div
@@ -36,7 +36,7 @@ const CategorySection = () => {
                     className="w-full h-full object-cover aspect-square max-md:rounded-t-lg"
                   />
                 </div>
-                <div className="md:order-2 p-8 sm:p-14 sm:mr-2">
+                <div className="md:order-2 px-6 md:px-14 sm:mr-2">
                   <div className="flex items-center gap-1.5">
                     <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left">
                       {section.title}
@@ -56,7 +56,7 @@ const CategorySection = () => {
                     <ReusableButton
                       text="Read More"
                       onClick={handleReadMoreClick}
-                      className="mt-6 uppercase font-semibold"
+                      className="mt-4"
                     />
                   </div>
                 </div>
@@ -70,7 +70,7 @@ const CategorySection = () => {
                     className="w-full h-full object-cover aspect-square max-md:rounded-t-lg"
                   />
                 </div>
-                <div className="md:order-1 p-8 sm:p-14 sm:mr-2">
+                <div className="md:order-1 px-6 md:px-14 sm:mr-2">
                   <div className="flex items-center gap-1.5">
                     <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left">
                       {section.title}
@@ -89,7 +89,7 @@ const CategorySection = () => {
                     <ReusableButton
                       text="Read More"
                       onClick={handleReadMoreClick}
-                      className="mt-6 uppercase font-semibold"
+                      className="mt-4"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
### What does this PR do?
Applies small styling fixes to match the design specifications on mobile view.

### Description of Task to be completed?
- Adjust the gap between the image and title in the category sections on mobile view — the gap should be slightly smaller.
- Add more horizontal padding (left and right) on the "Our Work" category section in mobile view, according to the design file.
- Add top spacing to the scroll effect triggered by HeroBannerNav buttons.

### How should this be manually tested?
- Go to the category sections on mobile view and verify the gap between image and title is slightly reduced.
- Check that the "Our Work" section on mobile view has increased padding on the left and right sides.

### Any background context you want to provide?
