### PR TITLE
Enhance CategorySection: Improve click handling for titles and arrows…

### DIFF
--- a/src/components/ourWorkPage/categorySection.jsx
+++ b/src/components/ourWorkPage/categorySection.jsx
@@ -37,16 +37,20 @@ const CategorySection = () => {
                   />
                 </div>
                 <div className="md:order-2 px-6 md:px-14 sm:mr-2">
-                  <div className="flex items-center gap-1.5">
-                    <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left">
+                  <div
+                    className="flex items-center gap-1.5 cursor-pointer group"
+                    onClick={handleReadMoreClick}
+                  >
+                    <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left  group-hover:underline underline-offset-4">
                       {section.title}
                     </h2>
-                    <img
-                      src="/assets/placeholder-images/Arrow-forward-circle.png"
-                      alt="Arrow to the right"
-                      onClick={handleReadMoreClick}
-                      className="w-[24px] h-[24px] md:hidden"
-                    />
+                    <button type="button" className="block md:hidden">
+                      <img
+                        src="/assets/placeholder-images/Arrow-forward-circle.png"
+                        alt="Arrow to the right"
+                        className="w-[24px] h-[24px] cursor-pointer group-hover:translate-x-1 transition-transform "
+                      />
+                    </button>
                   </div>
                   <p className="line-clamp-7 text-transparent bg-clip-text bg-gradient-to-t from-transparent to-black mt-4">
                     {section.content}
@@ -71,16 +75,21 @@ const CategorySection = () => {
                   />
                 </div>
                 <div className="md:order-1 px-6 md:px-14 sm:mr-2">
-                  <div className="flex items-center gap-1.5">
-                    <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left">
+                  <div
+                    className="flex items-center gap-1.5 cursor-pointer group"
+                    onClick={handleReadMoreClick}
+                  >
+                    <h2 className="text-2xl md:text-2xl font-bold sm:font-semibold text-left  group-hover:underline underline-offset-4">
                       {section.title}
                     </h2>
-                    <img
-                      src="/assets/placeholder-images/Arrow-forward-circle.png"
-                      alt="Arrow to the right"
-                      onClick={handleReadMoreClick}
-                      className="w-[24px] h-[24px] md:hidden"
-                    />
+
+                    <button type="button" className="block md:hidden">
+                      <img
+                        src="/assets/placeholder-images/Arrow-forward-circle.png"
+                        alt="Arrow to the right"
+                        className="w-[24px] h-[24px] cursor-pointer group-hover:translate-x-1 transition-transform "
+                      />
+                    </button>
                   </div>
                   <p className="line-clamp-7 text-transparent bg-clip-text bg-gradient-to-t from-transparent to-black mt-4">
                     {section.content}


### PR DESCRIPTION
… with updated styles and added hover effects

### What does this PR do?
This PR improves the user experience and accessibility of the "Our Work" category sections by making the category title clickable and wrapping the arrow icon in a button element.

### Description of Task to be completed?
- Make the title in each "Our Work" category section clickable, linking to the respective category page.
- Apply the same clickable behavior to the title across all breakpoints (mobile, tablet, and desktop).
- Wrap the arrow icon in a <button> element to ensure proper keyboard accessibility and semantic HTML.

### How should this be manually tested?
- Go to the "Our Work" section on the page.
- On mobile, tablet, and desktop, click on the title of any category — it should navigate to the respective category page.
- Verify that the arrow icon is now inside a <button> element and is reachable via keyboard (e.g., using the Tab key).
- Confirm that functionality remains the same as before — the arrow also navigates to the correct page.

### Any background context you want to provide?
