### PR TITLE
Setup supportPage tsx file add this file to routes

### DIFF
--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -1,0 +1,17 @@
+import ErrorBoundary from "../components/ErrorBoundary";
+import React from 'react';
+
+function SupportPage() {
+  
+
+  return (
+    <ErrorBoundary>
+      <div className="w-full flex justify-center items-center flex-col mt-60 mb-200 ">
+        <h1 className="text-4xl  text-center font-[var(--font-justAnotherHand)]">Support</h1>
+        
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+export default SupportPage;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -15,6 +15,7 @@ import OurWork from '../pages/OurWork';
 import CategorySpecific from '../pages/OurWorkSpecific.jsx';
 import Placeholder from '../pages/PlaceHolder';
 import TestTranslations from '../pages/TestTranslations';
+import SupportPage from '../pages/SupportPage.jsx';
 
 const AppRoutes = () => {
   const [loading, setLoading] = useState(false);
@@ -45,6 +46,7 @@ const AppRoutes = () => {
             <Route path="/work-specific" element={<CategorySpecific />} />
             <Route path="/test-translations" element={<TestTranslations />} />
             <Route path="*" element={<NotFound />} />
+            <Route path="/donate" element={<SupportPage />} />
             <Route path="/placeholder" element={<Placeholder />} />
             <Route path="/news-post" element={<NewsPost />} />
           </Route>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -46,7 +46,7 @@ const AppRoutes = () => {
             <Route path="/work-specific" element={<CategorySpecific />} />
             <Route path="/test-translations" element={<TestTranslations />} />
             <Route path="*" element={<NotFound />} />
-            <Route path="/donate" element={<SupportPage />} />
+            <Route path="/support" element={<SupportPage />} />
             <Route path="/placeholder" element={<Placeholder />} />
             <Route path="/news-post" element={<NewsPost />} />
           </Route>


### PR DESCRIPTION
### ✅What does this PR do?

- Sets up the SupportPage.jsx component with base layout and configures routing for the /support page.



### ✅Description of Task to be completed?

- Create SupportPage.jsx under src/pages/

- Add a base layout including a h1 with the text “Support”

- Set up routing using React Router to render SupportPage at path /support
 


### ✅How should this be manually tested?

- Run the development server using npm start or yarn dev

- Navigate to http://localhost:5173/support in the browser

- Verify that the page renders with a heading: Support

 

### ✅Any background context you want to provide?

- This base setup allows other team members to start adding specific content and components to the Support page. Routing must be in place before their work can begin
