### PR TITLE
Add SupportUsSection with working CTA and placeholder support page

### DIFF
--- a/src/components/SupportUsSection.jsx
+++ b/src/components/SupportUsSection.jsx
@@ -1,37 +1,44 @@
-import locales from '../../public/locales/locales.en.json';
+import { Link } from 'react-router-dom';
 import ReusableButton from './buttons/reusableButton';
 
 const SupportUsSection = () => {
   return (
-    <div className="md:w-[85%] w-[95%] mx-auto my-10  md:h-[626px] p-8 bg-[var(--color-ivory-beige)] border border-[#e6d9c2] rounded-md shadow-[6px_6px_3px_rgba(238,99,82,0.7)]">
+    <section
+      className="bg-[#fff3cc] border-[4px] border-[#f88b5c] shadow-[6px_6px_0_#f88b5c] rounded-md 
+                 w-[95%] md:w-[85%] mx-auto my-10 p-8"
+    >
       <div className="flex flex-col items-center space-y-10 my-5">
-        <h2 className="text-4xl  text-center font-[var(--font-justAnotherHand)]">
-          {' '}
-          {locales.screens.supportUs.title}
+        <h2 className="text-4xl md:text-5xl text-center font-[var(--font-justAnotherHand)] font-normal">
+          Support Us
         </h2>
 
-        <div className="space-y-4 m-7 text-lg max-w-3xl mx-auto font-[var(--font-sans)]">
-          <p>{locales.screens.supportUs.description}</p>
-
+        <div className="space-y-6 text-lg max-w-[700px] px-6 md:px-10 mx-auto text-left 
+                        font-[var(--font-sans)] leading-relaxed text-[#333]">
           <p>
-            The families of the children are also included in the food program
-            and receive monthly distributions of food and hygiene products.
+            The funds that come in go towards covering everything from food, clothing,
+            education, equipment, healthcare, medicines, and dental care for the children,
+            as well as the operation of the music school and salaries for our staff.
           </p>
-
           <p>
-            We are constantly working to improve the living conditions of the
-            children, and we use much of the surplus we have to repair houses
-            and homes.
+            The families of the children are also included in the food program and receive
+            monthly distributions of food and hygiene products.
+          </p>
+          <p>
+            We are constantly working to improve the living conditions of the children, and
+            we use much of the surplus we have to repair houses and homes.
           </p>
         </div>
 
-        <ReusableButton
-          text="SUPPORT"
-          href="#"
-          className="bg-[var(--color-sunset-red)] hover:bg-[var(--color-hover-red)] text-white font-medium px-10 py-2 rounded-md text-2xl"
-        />
+        <Link to="/support" aria-label="Navigate to the Support page">
+          <ReusableButton
+            text="SUPPORT"
+            type="button"
+            className="!bg-[var(--color-sunset-red)] !text-white hover:!bg-[#d9534f] 
+                       hover:!text-white !border-none px-10 py-3 text-2xl font-bold rounded-md"
+          />
+        </Link>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/pages/Event.jsx
+++ b/src/pages/Event.jsx
@@ -1,12 +1,8 @@
 import ErrorBoundary from '../components/ErrorBoundary';
+import SupportUsSection from '../components/SupportUsSection';
 import EventHeader from '../components/event/EventHeader';
 import EventVisuals from '../components/event/EventVisuals';
 import ReasonsToAttend from '../components/event/ReasonsToAttend';
-
-// Placeholder components – will be replaced later
-// const EventHeader = () => <div>EventHeader placeholder</div>;
-// WhyAttend = () => <div>WhyAttend placeholder</div>;
-const SupportSection = () => <div>SupportSection placeholder</div>;
 
 export default function Event() {
   return (
@@ -20,7 +16,7 @@ export default function Event() {
           <ReasonsToAttend />
         </section>
         <section>
-          <SupportSection />
+          <SupportUsSection />
         </section>
       </div>
     </ErrorBoundary>

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -1,0 +1,13 @@
+// TEMPORARY PAGE: This placeholder is only to support navigation testing for the Support CTA button.
+// The actual Support page content will be built by another team (as confirmed by the Scrum Master).
+// Once their work is ready, this file should be deleted or replaced.
+
+export default function SupportPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-3xl font-bold text-center text-gray-700">
+        Support Page Coming Soon
+      </h1>
+    </div>
+  );
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -7,6 +7,7 @@ import LoadingSpinner from '../components/LoadingSpinner.jsx';
 import MainLayout from '../components/MainLayout.jsx';
 import About from '../pages/About';
 import Contact from '../pages/Contact';
+import Event from '../pages/Event';
 import Home from '../pages/Home';
 import News from '../pages/News';
 import NewsPost from '../pages/NewsPost';
@@ -14,9 +15,9 @@ import NotFound from '../pages/NotFound';
 import OurWork from '../pages/OurWork';
 import CategorySpecific from '../pages/OurWorkSpecific.jsx';
 import Placeholder from '../pages/PlaceHolder';
+// TEMP: Placeholder Support page for CTA button testing
+import SupportPage from '../pages/SupportPage';
 import TestTranslations from '../pages/TestTranslations';
-import Event from "../pages/Event";
-
 
 const AppRoutes = () => {
   const [loading, setLoading] = useState(false);
@@ -50,7 +51,10 @@ const AppRoutes = () => {
             <Route path="/placeholder" element={<Placeholder />} />
             <Route path="/news-post" element={<NewsPost />} />
             <Route path="/event" element={<Event />} />
-
+            {/*
+  TEMP ROUTE: Will be replaced when the actual Support page is implemented
+*/}
+            <Route path="/support" element={<SupportPage />} />
           </Route>
         </Routes>
       )}


### PR DESCRIPTION
### What this PR includes:
- Adds the `SupportUsSection` to the Event page
- Integrates the shared `ReusableButton` component
- Button navigates to `/support` per User Story 3
- Adds a **temporary placeholder SupportPage.jsx** to complete routing

---

###  Manually tested:
- Button styling matches Figma design
- Navigates correctly to `/support`
- Works with keyboard navigation
- Screen reader accessible via aria-label

---

###  Notes:
- `/support` page is a **temporary placeholder** — another team will build the final page
- This PR replaces a previous conflicted PR to keep the branch clean and isolated

---

###  Description of Task to be completed:
- Build a Support Us section based on Figma design
- Use a reusable CTA button linking to the `/support` route
- Ensure accessibility (keyboard + screen reader support)

---

###  How should this be manually tested?
1. Run `npm run dev`
2. Go to `/event` page
3. Scroll down to the Support Us section
4. Press `Tab` to focus the button
5. Press `Enter` — it should take you to `/support`
6. Confirm the placeholder page loads correctly

---

###  Background context:
- This task fulfills User Story 3: "Support Button CTA"
- The support page itself is being handled by a different team; this just sets up routing and UI

---

Ready for review!
