### PR TITLE
feat: make 'Upcoming Events' section responsive and accessible (#1191)

### DIFF
--- a/src/components/event/Eventcard.jsx
+++ b/src/components/event/Eventcard.jsx
@@ -9,7 +9,7 @@ const EventCard = ({
   link = '#',
 }) => {
   return (
-    <div className="flex flex-col items-center w-[340px]">
+    <article className="flex flex-col items-center w-full max-w-[340px]">
       {image && (
         <img
           src={image}
@@ -18,7 +18,7 @@ const EventCard = ({
         />
       )}
 
-      <div className="flex flex-col gap-2 mt-4 font-montserrat w-[276px]">
+      <div className="flex flex-col gap-2 mt-4 font-montserrat w-full max-w-[276px]">
         <time
           dateTime={date}
           className="text-sm text-[var(--color-dark-green)]"
@@ -30,13 +30,19 @@ const EventCard = ({
           <h2 className="font-freeman text-[30px] font-bold leading-[150%] max-w-[90%]">
             {title}
           </h2>
-          <a href={link} className="shrink-0 mt-1">
+          <a
+            href={link}
+            aria-label={`Read more about ${title}`}
+            className="shrink-0 mt-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-dark-green)] rounded-full"
+          >
             <svg
               width="10"
               height="18"
               viewBox="0 0 10 18"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
+              role="img"
+              aria-hidden="true"
             >
               <path
                 d="M9.20261 8.02822C9.73846 8.56533 9.73846 9.4376 9.20261 9.97471L2.34379 16.8497C1.80794 17.3868 0.93773 17.3868 0.401884 16.8497C-0.133961 16.3126 -0.133961 15.4403 0.401884 14.9032L6.2919 8.99932L0.406171 3.09541C-0.129675 2.5583 -0.129675 1.68604 0.406171 1.14893C0.942016 0.611816 1.81223 0.611816 2.34807 1.14893L9.2069 8.02393L9.20261 8.02822Z"
@@ -63,7 +69,7 @@ const EventCard = ({
           </div>
         )}
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -110,7 +110,7 @@ function News() {
             </h2>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-14 place-items-center mb-14">
+          <div className="flex flex-wrap justify-center gap-x-10 gap-y-12 mb-14">
             {mockEvents.slice(0, 12).map((event, index) => (
               <EventCard key={index} {...event} />
             ))}

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -100,25 +100,33 @@ function News() {
             </div>
           )}
         </div>
-        <div id="eventsSection" className="mt-24">
+        <section id="eventsSection" aria-labelledby="upcoming-events-heading" className="mt-24">
           <div className="relative left-[calc(-50vw+50%)] w-screen h-[162px] bg-[var(--color-dark-green)] flex justify-center items-center mb-24">
-            <h2 className="font-justAnotherHand text-white text-[100px]">
+            <h2
+              id="upcoming-events-heading"
+              className="font-justAnotherHand text-white text-[48px] sm:text-[72px] md:text-[100px]"
+            >
               Upcoming events
             </h2>
           </div>
-          <div className="flex flex-wrap justify-center gap-x-10 gap-y-12 mb-14">
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-14 place-items-center mb-14">
             {mockEvents.slice(0, 12).map((event, index) => (
               <EventCard key={index} {...event} />
             ))}
           </div>
+
           <div className="flex justify-center mb-14">
-            <a href="#more-events" aria-label="Read More">
+            <a href="#more-events" aria-label="Scroll to more events" className="focus:outline-none focus-visible:ring-2 rounded-full">
+              <span className="sr-only">Scroll to more events</span>
               <svg
                 width="40"
                 height="20"
                 viewBox="0 0 40 20"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                role="img"
+                aria-hidden="true"
               >
                 <path
                   d="M39.2084 3.96313L21.4776 19.4931C21.2665 19.6774 21.0378 19.8077 20.7916 19.8839C20.5453 19.9613 20.2814 20 20 20C19.7186 20 19.4547 19.9613 19.2084 19.8839C18.9622 19.8077 18.7335 19.6774 18.5224 19.4931L0.738786 3.96313C0.246262 3.53303 0 2.99539 0 2.35023C0 1.70507 0.263852 1.15207 0.791557 0.691244C1.31926 0.230413 1.93492 0 2.63852 0C3.34213 0 3.95778 0.230413 4.48549 0.691244L20 14.2396L35.5145 0.691244C36.007 0.261137 36.6135 0.0460815 37.334 0.0460815C38.0559 0.0460815 38.6807 0.276497 39.2084 0.737326C39.7361 1.19816 40 1.73579 40 2.35023C40 2.96467 39.7361 3.5023 39.2084 3.96313Z"
@@ -127,7 +135,7 @@ function News() {
               </svg>
             </a>
           </div>
-        </div>
+        </section>
       </div>
     </ErrorBoundary>
   );


### PR DESCRIPTION
### What does this PR do?

This pull request adds responsive layout adjustments and basic accessibility improvements to the "Upcoming Events" section on the /event page.

### Description of Task to be completed?

- Implement responsive grid layout using Tailwind breakpoints (mobile, tablet, desktop)
- 
- Scale font sizes and spacing for readability across devices
- 
- Add descriptive alt text to images
- 
- Ensure semantic HTML structure.
- 
- Add aria-label attributes to interactive icons for screen reader support
- 
- Confirm keyboard accessibility with focus indicators and tab order

### How should this be manually tested?

1. Navigate to the /event page
2. Resize the browser or use Chrome DevTools to test on mobile, tablet, and desktop breakpoints
3. Confirm that:
- Layout adapts properly across all screen sizes
- All text and images scale without overflow or clipping
- Keyboard navigation flows logically with visible focus
- SVG links/buttons have screen reader labels
4. Run a Lighthouse or Axe audit to confirm accessibility improvements

### Any background context you want to provide?

This work is scoped to the "Upcoming Events" section only. Broader performance or SEO issues identified in Lighthouse reports are outside the scope of this ticket and should be handled separately. This branch was created from feature/event-page.
