### PR TITLE
Feature/implement contact form

### DIFF
--- a/src/components/SupportPage/SupportContactForm.jsx
+++ b/src/components/SupportPage/SupportContactForm.jsx
@@ -2,7 +2,7 @@ import TextInput from '../../components/supportForms/TextInput';
 
 const ContactForm = () => {
   return (
-    <form className="max-w-4xl mx-auto p-6 bg-[#B2CAC2] mt-20 shadow-md rounded-sm">
+    <form className="max-w-4xl p-6 bg-[#B2CAC2] shadow-md rounded-sm">
       <h2 className="text-2xl font-bold mb-6 text-center">Contact Us</h2>
       <div className="grid grid-cols-1 font-montserrat md:grid-cols-2 gap-6">
         {/* Left Column */}

--- a/src/components/SupportPage/SupportContactForm.jsx
+++ b/src/components/SupportPage/SupportContactForm.jsx
@@ -1,6 +1,3 @@
-// ContactForm.jsx
-import React from 'react';
-
 import TextInput from '../../components/supportForms/TextInput';
 
 const ContactForm = () => {

--- a/src/components/SupportPage/SupportOptions.jsx
+++ b/src/components/SupportPage/SupportOptions.jsx
@@ -6,6 +6,9 @@ import SupportOptionSingle from './SupportOptionSingle.jsx';
 // import DonationsForm from '../forms/DonationsForm';
 // import FundraisingForm from '../forms/FundraisingForm';
 
+import ContactForm from './SupportContactForm.jsx';
+
+
 const exampleForm = () => (
   <form className="lg:grid lg:grid-cols-2 flex flex-col gap-[12px] md:gap-[24px] justify-center bg-[var(--color-mint-green)] rounded-[5px] pt-[32px] pb-[28px] px-[48px]">
     <h2 className="col-span-2 text-center md:text-[32px] text-[20px]">
@@ -54,9 +57,9 @@ const exampleForm = () => (
 );
 
 const formMap = {
-  volunteer: exampleForm, // replaced by correct form when completed
+  volunteer: ContactForm, // replaced by correct form when completed
   donations: exampleForm, // replaced by correct form when completed
-  fundraising: exampleForm, // replaced by correct form when completed
+  fundraising: ContactForm, // replaced by correct form when completed
 };
 
 const SupportOptions = ({ openModal }) => {


### PR DESCRIPTION
### What does this PR do?

- Imports the ContactForm component and adds it to the formMap in SupportOptions.

### Description of Task to be completed?

- Import ContactForm into SupportOptions.jsx.
- Add ContactForm as the form component for relevant support options in the formMap.

### How should this be manually tested?

1. Go to the Support page.
2. Click "Go to Form" for a support option mapped to ContactForm (e.g., Volunteer or Fundraising).
3. Verify that the ContactForm appears in the modal.

### Any background context you want to provide?

- This change prepares the Support page to use the actual ContactForm for relevant support options, replacing the placeholder/example form.