### PR TITLE
Limit content width on widescreens (Contact page)

### DIFF
--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -11,7 +11,7 @@ function Contact() {
           Contact Us
         </h1>
         <MissionStatement />
-        <section className="p-10 bg-[var(--color-mint-green)] mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 border-1 rounded-sm m-10 w-11/12 md:divide-x">
+        <section className="p-10 bg-[var(--color-mint-green)] mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 border-1 rounded-sm m-10 w-11/12 max-w-[1200px] md:divide-x">
           <div className="order-2 md:order-1">
             <ContactInfo />
           </div>


### PR DESCRIPTION
✅ What does this PR do?
Adds a maximum width limitation to the Contact page to prevent layout from stretching too far on widescreens (1920px and above).

📌 Description of Task to be completed?
- Apply max-width: 1200px constraint to the main content area of the Contact page.
- Ensure layout consistency with other pages like the MissionStatement page, which already has similar constraints.

🧪 How should this be manually tested?
1. Open the Contact page on a screen wider than 1920px.
2. Confirm that the content no longer stretches edge to edge but is centered with a max width of 1200px.
3. Resize the window below 1920px to verify the layout still adapts properly on smaller screens.

📎 Any background context you want to provide?
This change improves readability and visual consistency across pages by aligning the layout behavior with the MissionStatement page, which already avoids excessive width on large screens.

PS:
As a person with a widescreen larger than 1920 myself. It's easier for me to test this, but you could mock it via a website such as [Screenfly](https://screenfly.org/). As it can mock all screen sizes using the custom setting for screen size.

HOW:
enter localhost link as url
click (C) to enter your desired mock values of a screen.