### PR TITLE
feat(policy): add accordion expand/collapse to Privacy Policy page

### DIFF
--- a/src/pages/PolicyAccordian.jsx
+++ b/src/pages/PolicyAccordian.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+
+// tiny chevron (no extra deps)
+function Chevron({ open }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className={`h-4 w-4 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
+    >
+      <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.17l3.71-2.94a.75.75 0 1 1 .94 1.17l-4.24 3.37a.75.75 0 0 1-.94 0L5.21 8.4a.75.75 0 0 1 .02-1.18Z" />
+    </svg>
+  );
+}
+
+// smooth height transition (0 <-> content), then settle on 'auto'
+function useAutoHeight(open) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    el.style.overflow = 'hidden';
+    el.style.transitionProperty = 'height';
+    el.style.transitionDuration = '300ms';
+
+    if (open) {
+      el.style.height = '0px';
+      requestAnimationFrame(() => {
+        el.style.height = `${el.scrollHeight}px`;
+      });
+      const onEnd = () => (el.style.height = 'auto');
+      el.addEventListener('transitionend', onEnd, { once: true });
+      return () => el.removeEventListener('transitionend', onEnd);
+    } else {
+      const h = el.getBoundingClientRect().height;
+      el.style.height = `${h}px`;
+      requestAnimationFrame(() => {
+        el.style.height = '0px';
+      });
+    }
+  }, [open]);
+
+  return ref;
+}
+
+/**
+ * Usage:
+ * <PolicyAccordian sectionId="scope" titleId="scope-title" title="SCOPE">
+ *   <p>…content…</p>
+ * </PolicyAccordian>
+ *
+ * Keeps your existing ids + aria-labelledby.
+ * Multiple sections can be open at once (meets AC). If you later want
+ * "one open at a time", manage open state in the parent.
+ */
+export default function PolicyAccordian({
+  sectionId,
+  titleId,
+  title,
+  children,
+  defaultOpen = false,
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = `${sectionId}-panel`;
+  const panelRef = useAutoHeight(open);
+
+  return (
+    <section id={sectionId} className="space-y-0" aria-labelledby={titleId}>
+      <h2 id={titleId} className="text-2xl font-semibold leading-snug">
+        <button
+          type="button"
+          aria-controls={panelId}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="w-full py-6 flex items-center justify-between text-left uppercase focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black cursor-pointer"
+        >
+          <span className="text-lg sm:text-xl">{title}</span>
+          <Chevron open={open} />
+        </button>
+      </h2>
+
+      <div
+        id={panelId}
+        role="region"
+        aria-labelledby={titleId}
+        ref={panelRef}
+        style={{ height: 0 }}
+        className="will-change-[height]"
+      >
+        <div className="pb-6 pt-1 text-sm sm:text-base text-neutral-700">
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 
 import ErrorBoundary from '../components/ErrorBoundary';
+import PolicyAccordion from './PolicyAccordian';
+
+// same folder as this file
 
 export default function PrivacyPolicy() {
   const [navOffset, setNavOffset] = useState(199); // fallback matches your h-[199px] for navbar
@@ -25,9 +28,9 @@ export default function PrivacyPolicy() {
         role="main"
         aria-labelledby="pp-title"
         style={{ paddingTop: navOffset + GAP }}
-        className="mx-auto max-w-3xl px-4 sm:px-6 md:px-8 pb-10 sm:pb-12 md:pb-16 space-y-12 md:space-y-16"
+        className="mx-auto max-w-3xl px-4 sm:px-6 md:px-8 pb-10 sm:pb-12 md:pb-16 space-y-0"
       >
-        <header>
+        <header className="mb-8 sm:mb-10 md:mb-12">
           <h1
             id="pp-title"
             style={{ scrollMarginTop: navOffset + GAP }}
@@ -35,7 +38,7 @@ export default function PrivacyPolicy() {
           >
             Privacy Policy
           </h1>
-          <p className='text-center justify-center text-sm pt-9 '>
+          <p className="text-center justify-center text-sm pt-9">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
@@ -43,169 +46,121 @@ export default function PrivacyPolicy() {
           </p>
         </header>
 
-        {/* Sections as placeholders – teammates will fill in / add expand-collapse */}
-        <section id="scope" className="space-y-4" aria-labelledby="scope-title">
-          <h2 id="scope-title" className="text-2xl font-semibold leading-snug">
-            SCOPE
-          </h2>
+        {/* Accordion sections (IDs + aria-labelledby preserved) */}
+        <PolicyAccordion sectionId="scope" titleId="scope-title" title="SCOPE">
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="data-collection"
-          className="space-y-4"
-          aria-labelledby="collect-title"
+        <PolicyAccordion
+          sectionId="data-collection"
+          titleId="collect-title"
+          title="DATA WE COLLECT"
         >
-          <h2
-            id="collect-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            DATA WE COLLECT
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="data-we-dont-collect"
-          className="space-y-4"
-          aria-labelledby="data-we-dont-collect-title"
+        <PolicyAccordion
+          sectionId="data-we-dont-collect"
+          titleId="data-we-dont-collect-title"
+          title={"DATA WE DON'T COLLECT"}
         >
-          <h2
-            id="data-we-dont-collect"
-            className="text-2xl font-semibold leading-snug"
-          >
-            DATA WE DON&apos;T COLLECT
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
-        <section
-          id="use-of-information"
-          className="space-y-4"
-          aria-labelledby="use-of-information-title"
-        >
-          <h2
-            id="use-of-information-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            USE OF INFORMATION
-          </h2>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-            sodales lorem in eros elementum tristique. Duis congue nibh a nibh
-            viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
-            luctus lorem. Lorem ipsum dolor sit amet, consectetur.
-          </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="data-security"
-          className="space-y-4"
-          aria-labelledby="data-security-title"
+        <PolicyAccordion
+          sectionId="use-of-information"
+          titleId="use-of-information-title"
+          title="USE OF INFORMATION"
         >
-          <h2
-            id="data-security-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            DATA SECURITY
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="third-party-links"
-          className="space-y-4"
-          aria-labelledby="third-party-links-title"
+        <PolicyAccordion
+          sectionId="data-security"
+          titleId="data-security-title"
+          title="DATA SECURITY"
         >
-          <h2
-            id="third-party-links-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            THIRD PARTY LINKS
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
-        <section
-          id="childrens-privacy"
-          className="space-y-4"
-          aria-labelledby="childrens-privacy-title"
-        >
-          <h2
-            id="childrens-privacy-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            CHILDREN&apos;S PRIVACY
-          </h2>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-            sodales lorem in eros elementum tristique. Duis congue nibh a nibh
-            viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
-            luctus lorem. Lorem ipsum dolor sit amet, consectetur.
-          </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="changes-to-our-privacy"
-          className="space-y-4"
-          aria-labelledby="changes-to-our-privacy-title"
+        <PolicyAccordion
+          sectionId="third-party-links"
+          titleId="third-party-links-title"
+          title="THIRD PARTY LINKS"
         >
-          <h2
-            id="changes-to-our-privacy-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            CHANGES TO OUR PRIVACY
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
+        </PolicyAccordion>
 
-        <section
-          id="governing-law"
-          className="space-y-4"
-          aria-labelledby="governing-law-title"
+        <PolicyAccordion
+          sectionId="childrens-privacy"
+          titleId="childrens-privacy-title"
+          title={"CHILDREN'S PRIVACY"}
         >
-          <h2
-            id="governing-law-title"
-            className="text-2xl font-semibold leading-snug"
-          >
-            GOVERNING LAW
-          </h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
             sodales lorem in eros elementum tristique. Duis congue nibh a nibh
             viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
             luctus lorem. Lorem ipsum dolor sit amet, consectetur.
           </p>
-        </section>
-        <div className="text-sm  ">
+        </PolicyAccordion>
+
+        <PolicyAccordion
+          sectionId="changes-to-our-privacy"
+          titleId="changes-to-our-privacy-title"
+          title="CHANGES TO OUR PRIVACY"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            sodales lorem in eros elementum tristique. Duis congue nibh a nibh
+            viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
+            luctus lorem. Lorem ipsum dolor sit amet, consectetur.
+          </p>
+        </PolicyAccordion>
+
+        <PolicyAccordion
+          sectionId="governing-law"
+          titleId="governing-law-title"
+          title="GOVERNING LAW"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            sodales lorem in eros elementum tristique. Duis congue nibh a nibh
+            viverra posuere. Nullam sit amet diam volutpat, luctus velit non,
+            luctus lorem. Lorem ipsum dolor sit amet, consectetur.
+          </p>
+        </PolicyAccordion>
+
+        <div className="text-sm pt-6">
           <small>Updated: 00/00/00</small>
         </div>
       </main>


### PR DESCRIPTION
### What does this PR do?

- Added `PolicyAccordian.jsx` component for reusable, accessible expand/collapse sections.
- Integrated accordion into `PrivacyPolicy.jsx` with all original section IDs and aria-labelledby for semantics.
- Smooth height transition without layout jump.
- Keyboard support (Tab, Enter, Space).

### How to Test
1. Navigate to `/privacy-policy`.
2. Click on a section header — content expands/collapses smoothly.
3. Use keyboard:
   - Tab to a section header.
   - Press Enter or Space to toggle it.
4. Verify that spacing and layout match the Figma design.
5. Check that multiple sections can be expanded at once (as per spec).
6. Inspect with screen reader — expanded state is announced.

### Notes for QA
- All aria attributes follow WAI-ARIA Accordion guidelines.
- Visual style matches Figma; no divider lines between sections.
- Code isolated to sub-branch `feature/policy-page-accordion`; does not impact `feature/policy-page` until merged.

