### PR TITLE
Add redirection from all support forms to thank you modal

### DIFF
--- a/src/components/SupportPage/SupportContactForm.jsx
+++ b/src/components/SupportPage/SupportContactForm.jsx
@@ -1,25 +1,42 @@
 import { useState } from 'react';
+
 import { useNavigate } from 'react-router-dom';
 
 import TextInput from '../../components/supportForms/TextInput';
-import AgreementRadio from '../supportForms/AgreementRadio';
 import { SubmitButton } from '../buttons/SubmitButton/SubmitButton';
+import AgreementRadio from '../supportForms/AgreementRadio';
+import ThankYouModal from './ThankYouModal';
 
 /**
  * ContactForm component
  * @param {Object} props
  * @param {React.ReactNode} props.children
  * @param {Function} props.onSubmit
- * @param {string} [props.redirectTo='/thank-you']
+//  * @param {string} [props.redirectTo='/thank-you']
  */
-const ContactForm = ({ children, onSubmit, redirectTo = '/thank-you' }) => {
+
+/**
+ * Handles the donation form submission.
+ * Simulates async processing (e.g., API call) and redirects after 1s.
+ *
+ * @async
+ * @function handleContact
+ * @returns {Promise<void>}
+ */
+const ContactForm = ({ children, onSubmit }) => {
   const [agreed, setAgreed] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = async () => {
+  const handleContact = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  };
+
+  const handleSubmit = async (e) => {
+    if (e) e.preventDefault();
     const form = document.getElementById('support-contact-form');
 
-    // Trigger browser validation
     if (!form.checkValidity()) {
       form.reportValidity();
       return;
@@ -29,68 +46,75 @@ const ContactForm = ({ children, onSubmit, redirectTo = '/thank-you' }) => {
       alert('You must agree to terms and conditions before submitting.');
       return;
     }
-
-    if (onSubmit) {
-      await onSubmit();
-    }
-
-    if (redirectTo) {
+    try {
+      if (onSubmit) await onSubmit();
       setTimeout(() => {
-        navigate(redirectTo);
+        setShowModal(true);
       }, 1000);
+    } catch (error) {
+      console.error('Submit failed:', error);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <form
-      id="support-contact-form"
-      className="max-w-4xl p-6 bg-[#B2CAC2] shadow-md rounded-sm"
-      onSubmit={(e) => e.preventDefault()}
-    >
-      <h2 className="text-2xl font-bold mb-6 text-center">Contact Us</h2>
+    <>
+      <form
+        id="support-contact-form"
+        className="max-w-4xl p-6 bg-[#B2CAC2] shadow-md rounded-sm"
+        onSubmit={(e) => handleSubmit(e)}
+        onClick={handleContact}
+      >
+        <h2 className="text-2xl font-bold mb-6 text-center">Contact Us</h2>
 
-      <div className="grid grid-cols-1 font-montserrat md:grid-cols-2 gap-6">
-        <div className="space-y-4">
-          <TextInput label="First Name" id="firstName" required />
-          <TextInput label="Email" id="email" type="email" required />
-          <TextInput label="Address" id="address" required />
-          <TextInput label="City" id="city" required />
+        <div className="grid grid-cols-1 font-montserrat md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            <TextInput label="First Name" id="firstName" required />
+            <TextInput label="Email" id="email" type="email" required />
+            <TextInput label="Address" id="address" required />
+            <TextInput label="City" id="city" required />
+          </div>
+          <div className="space-y-4">
+            <TextInput label="Last Name" id="lastName" required />
+            <TextInput label="Phone Number" id="phone" type="tel" required />
+            <TextInput label="Postal Code" id="postalCode" required />
+            <TextInput label="Country" id="country" required />
+          </div>
         </div>
-        <div className="space-y-4">
-          <TextInput label="Last Name" id="lastName" required />
-          <TextInput label="Phone Number" id="phone" type="tel" required />
-          <TextInput label="Postal Code" id="postalCode" required />
-          <TextInput label="Country" id="country" required />
+
+        {children}
+
+        <div className="mt-6">
+          <AgreementRadio
+            name="terms"
+            value="agree"
+            checked={agreed}
+            onChange={() => setAgreed(true)}
+            label={
+              <>
+                By clicking Submit, you agree to our{' '}
+                <strong>Terms & Conditions</strong> and that you have read our{' '}
+                <strong>Privacy Policy</strong>.
+              </>
+            }
+          />
         </div>
-      </div>
 
-      {children}
-
-      <div className="mt-6">
-        <AgreementRadio
-          name="terms"
-          value="agree"
-          checked={agreed}
-          onChange={() => setAgreed(true)}
-          label={
-            <>
-              By clicking Submit, you agree to our <strong>Terms & Conditions</strong> and that you have read our{' '}
-              <strong>Privacy Policy</strong>.
-            </>
-          }
-        />
-      </div>
-
-      <div className="w-full flex justify-center items-center mt-[45px] md:mt-16 mb-[61px] md:mb-[20px]">
-        <SubmitButton
-          label="Submit"
-          type="button"
-          className="uppercase font-sans text-[24px] font-semibold"
-          disabled={!agreed}
-          onClick={handleSubmit}
-        />
-      </div>
-    </form>
+        <div className="w-full flex justify-center items-center mt-[45px] md:mt-16 mb-[61px] md:mb-[20px]">
+          <SubmitButton
+            label="Submit"
+            type="button"
+            className="uppercase font-sans text-[24px] font-semibold"
+            disabled={!agreed}
+            onClick={handleSubmit}
+          />
+        </div>
+      </form>
+      {showModal && (
+        <ThankYouModal loading={loading} onClose={() => setShowModal(false)} />
+      )}
+    </>
   );
 };
 

--- a/src/components/SupportPage/ThankYouModal.jsx
+++ b/src/components/SupportPage/ThankYouModal.jsx
@@ -4,7 +4,7 @@ import heartIcon from '/assets/placeholder-images/heartgreen.png';
 
 const ThankYouModal = ({ loading, onClose }) => {
   return (
-    <div className="fixed inset-0 bg-[#000000]/54 bg-opacity-50 flex justify-center items-center z-50">
+    <div className="fixed inset-10 bg-[#000000]/54 bg-opacity-50 flex justify-center items-center z-50">
       <div className="bg-white shadow-lg w-[376px] h-[429px] sm:w-[700px] sm:h-[600px] md:w-[1100px] md:h-[580px] lg:w-[1280px] lg:h-[650px] max-w-[90%] text-center relative flex flex-col justify-center items-center px-8">
         {/* Close button */}
         <button onClick={onClose} className="absolute top-7 right-7">

--- a/src/components/buttons/SubmitButton/useSubmitButton.jsx
+++ b/src/components/buttons/SubmitButton/useSubmitButton.jsx
@@ -19,6 +19,7 @@ export const useSubmitButton = (onSubmit) => {
     setIsLoading(true);
     try {
       await onSubmit();
+      setTimeout(() => {}, 5000);
       setIsSuccess(true);
     } catch (error) {
       console.error('Submit failed:', error);
@@ -29,7 +30,7 @@ export const useSubmitButton = (onSubmit) => {
 
   useEffect(() => {
     if (isSuccess) {
-      const timer = setTimeout(() => setIsSuccess(false), 2000);
+      const timer = setTimeout(() => setIsSuccess(false), 4000);
       return () => clearTimeout(timer);
     }
   }, [isSuccess]);

--- a/src/components/supportForms/ContactInterestForm.jsx
+++ b/src/components/supportForms/ContactInterestForm.jsx
@@ -1,9 +1,22 @@
 import ContactForm from '../SupportPage/SupportContactForm';
 import InterestedField from './InterestedField';
 
+/**
+ * Handles the donation form submission.
+ * Simulates async processing (e.g., API call) and redirects after 1s.
+ *
+ * @async
+ * @function handleContactIntrestFormSubmit
+ * @returns {Promise<void>}
+ */
+
 export function ContactInterestForm() {
+  const handleContactIntrestFormSubmit = async () => {
+    await new Promise((r) => setTimeout(r, 1000));
+
+  };
   return (
-    <ContactForm>
+    <ContactForm onSubmit={handleContactIntrestFormSubmit}>
       <div className="mt-[82px] mb-16">
         <InterestedField />
       </div>

--- a/src/components/supportForms/DonationForm.jsx
+++ b/src/components/supportForms/DonationForm.jsx
@@ -43,7 +43,7 @@ export function DonationForm() {
 
   const handleDonationSubmit = async () => {
     await new Promise((r) => setTimeout(r, 1000));
-    navigate('/thank-you');
+    // navigate('/thank-you');
   };
 
   return (


### PR DESCRIPTION
## What does this PR do?
 - Adds a redirection from all the support forms to the thank you modal after successful submission.

## Description of Task to be completed?
 - Update all support form submission handlers to trigger the thank you modal instead of navigating away.
 - Ensure consistent UX across all support forms.
 - Maintain existing validation and submission flow.

## How should this be manually tested?
 - Go to any support form page (e.g., Support, Contact, Donation).
 - Fill out all required fields and agree to the terms.
 - Click Submit.
 - Confirm that the thank you modal appears instead of a page redirect.
 
## Any background context you want to provide?
 - Previously, some forms redirected to a separate thank you page after submission.

For more info: https://github.com/NoroffFEU/musikkforandrerliv.no/issues/1247