### PR TITLE
chore(cms): switch backend from GitHub to Git Gateway for Decap config

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,5 +1,5 @@
 backend:
-  name: github
+  name: git-gateway
   repo: NoroffFEU/musikkforandrerliv.no
   branch: develop
   # local_backend: true


### PR DESCRIPTION
### What does this PR do?
Switches the Decap CMS backend from GitHub to Git Gateway so we can test Netlify Identity login and fix i18n access issues.

### Description of task to be completed?
- Updated `/public/admin/config.yml`
- Changed backend from `github` to `git-gateway`
- Kept `branch: develop` to ensure build consistency

### How should this be manually tested?
1. Run `npm run dev`
2. Visit `/admin`
3. Confirm that Netlify Identity login appears instead of GitHub OAuth

### Any background context?
This is part of the High Priority task: **Resolve i18n support issue caused by incompatibility between Decap CMS and React 19 (#1294)**
