### PR TITLE
Fetch into section from CMS

### DIFF
--- a/public/locales/locales.en.json
+++ b/public/locales/locales.en.json
@@ -46,11 +46,11 @@
     }
   ],
   "about": {
-    "title": "test",
-    "description": "test",
-    "contact_form_success_message": "test",
-    "contact_form_error_message": "test",
-    "contact_info_address": "test",
+    "title": "Let us introduce ourselves",
+    "description": "Mozika Manova Fiainana is a music school for deprived communities of young people in Antsirabe, Madagascar, founded January 2021 by the Norwegian violinist Eline Rodvelt Hansen and the Malagasy musician Dina Rasalina.\n\nThe school is a vibrant holistic community that not only provides music and art lessons, but also supports children from the most underprivileged backgrounds in Antsirabe with food, health care, learning supplies, clothing and shelter.",
+    "contact_form_success_message": "Thank you for your message! We'll get back to you soon.",
+    "contact_form_error_message": "Sorry, there was an error sending your message. Please try again.",
+    "contact_info_address": "Antsirabe, Madagascar",
     "contact_info_phone": 293848484
   }
 }

--- a/public/locales/locales.mg.json
+++ b/public/locales/locales.mg.json
@@ -4,6 +4,14 @@
     "intro": "intro",
     "hero_image": "/content/gallery/skjermbilde-2025-10-13-kl.-10.31.15.png"
   },
+  "about": {
+    "title": "Andao hifampitondra antsika",
+    "description": "Mozika Manova Fiainana dia sekoly mozika ho an'ireo vondrom-piarahamonina tsy manana fahafahana amin'ny tanora ao Antsirabe, Madagasikara, niorina tamin'ny Janoary 2021 tamin'ny mpitendry violina norveziana Eline Rodvelt Hansen sy ny mpitendry mozika malagasy Dina Rasalina.\n\nNy sekoly dia vondrom-piarahamonina mavitrika izay tsy manome fiofanana mozika sy zavakanto fotsiny, fa manohana koa ny ankizy avy amin'ny fiarahamonina tsy manana fahafahana indrindra ao Antsirabe amin'ny sakafo, fikarakarana ara-pahasalamana, fitaovana fianarana, akanjo ary trano fialofana.",
+    "contact_form_success_message": "Misaotra anao noho ny hafatrao! Hiverina amin'ny hafatrao izahay tsy ho ela.",
+    "contact_form_error_message": "Miala tsiny, nisy fahadisoana nandefasana ny hafatrao. Andramo indray azafady.",
+    "contact_info_address": "Antsirabe, Madagasikara",
+    "contact_info_phone": 293848484
+  },
   "news-and-events": {
     "title": "Testing",
     "date": "2025-10-21T15:34:00.000+01:00",

--- a/public/locales/locales.no.json
+++ b/public/locales/locales.no.json
@@ -1,0 +1,28 @@
+{
+  "home": {
+    "title": "Hjemmeside norsk",
+    "intro": "intro",
+    "hero_image": "/content/gallery/skjermbilde-2025-10-13-kl.-10.31.15.png"
+  },
+  "about": {
+    "title": "La oss introdusere oss selv",
+    "description": "Mozika Manova Fiainana er en musikkskole for utsatte samfunn av unge mennesker i Antsirabe, Madagaskar, grunnlagt januar 2021 av den norske fiolinisten Eline Rodvelt Hansen og den madagassiske musikeren Dina Rasalina.\n\nSkolen er et levende helhetlig samfunn som ikke bare gir musikk- og kunsttimer, men også støtter barn fra de mest underprivilegerte bakgrunnene i Antsirabe med mat, helsevesen, læringsmateriell, klær og husly.",
+    "contact_form_success_message": "Takk for din melding! Vi kommer tilbake til deg snart.",
+    "contact_form_error_message": "Beklager, det oppstod en feil ved sending av din melding. Prøv igjen.",
+    "contact_info_address": "Antsirabe, Madagaskar",
+    "contact_info_phone": 293848484
+  },
+  "news-and-events": {
+    "title": "Testing",
+    "date": "2025-10-21T15:34:00.000+01:00",
+    "featured_image": "/content/gallery/skjermbilde-2025-10-13-kl.-10.31.15.png",
+    "excerpt": "Testing",
+    "content": "Denne testingen er vanskelig",
+    "event_details": {
+      "location": "Nigeria",
+      "start_time": "2025-10-21T15:34:00.000+01:00",
+      "end_time": "2025-10-21T15:34:00.000+01:00",
+      "organizer": "PGR"
+    }
+  }
+}

--- a/src/components/about/AboutUsSection.jsx
+++ b/src/components/about/AboutUsSection.jsx
@@ -1,32 +1,44 @@
+import { useTranslation } from 'react-i18next';
 import aboutUsPageContent from '../../data/about-us-page-content.json';
 
-//Hello Testing
 const AboutUsSection = () => {
-  const contentSections = aboutUsPageContent.sections.filter(
-    (section) => section.title || section.supporters,
+  const { t } = useTranslation();
+  
+  // Get intro content from CMS
+  const introTitle = t('about.title', 'Let us introduce ourselves');
+  const introDescription = t('about.description', 'Mozika Manova Fiainana is a music school for deprived communities of young people in Antsirabe, Madagascar, founded January 2021 by the Norwegian violinist Eline Rodvelt Hansen and the Malagasy musician Dina Rasalina.\n\nThe school is a vibrant holistic community that not only provides music and art lessons, but also supports children from the most underprivileged backgrounds in Antsirabe with food, health care, learning supplies, clothing and shelter.');
+  
+  // Get the intro image from the first section of the static data as fallback
+  const introImage = aboutUsPageContent.sections[0]?.image || '';
+  const introImageAlt = aboutUsPageContent.sections[0]?.imageAlt || 'About section image';
+
+  // Get other sections from static data (excluding the first intro section and supporters)
+  const otherSections = aboutUsPageContent.sections.filter(
+    (section, index) => index > 0 && !section.supporters,
   );
 
   return (
     <section id="AboutUsSection" className="w-full pt-2">
-      {contentSections.map((section, index) => {
-        const isFirst = index === 0;
-
-        // Check if section has standard content or is a supporters section
-        if (section.supporters) {
-          return null; // We'll render this separately in the About page
-        }
-
-        return (
-          <InfoSection
-            key={section.id}
-            title={section.title}
-            content={section.content}
-            image={section.image}
-            imageAlt={section.imageAlt}
-            layout={isFirst ? 'intro' : 'standard'}
-          />
-        );
-      })}
+      {/* Intro section from CMS */}
+      <InfoSection
+        title={introTitle}
+        content={introDescription}
+        image={introImage}
+        imageAlt={introImageAlt}
+        layout="intro"
+      />
+      
+      {/* Other sections from static data */}
+      {otherSections.map((section, index) => (
+        <InfoSection
+          key={section.id}
+          title={section.title}
+          content={section.content}
+          image={section.image}
+          imageAlt={section.imageAlt}
+          layout="standard"
+        />
+      ))}
     </section>
   );
 };


### PR DESCRIPTION
Updated About Us Section to dynamically fetch intro from CMS

Replaced static JSON data with CMS-driven content for intro section. Added useTranslation hook to fetch about.title and about.description from locale files. Maintained fallback values to ensure content displays even if translations missing.

Preserved existing static data for other sections (non-intro content)

Updated locale files with proper translations:

English: Added complete about section with title and description. Malagasy: Added Malagasy translations for about section. Norwegian: Created new Norwegian locale file with translations. Ensured language switching updates intro content dynamically Kept intro image from static data as fallback for visual consistency

The intro section now responds to language changes and can be managed through the CMS admin interface while maintaining the existing design and functionality.

Outcome: Dynamic CMS content fetching for AboutUsSection intro.

### What does this PR do?

This PR updates the AboutUsSection.jsx component to dynamically fetch the intro section content from the CMS instead of using static JSON data. The component now uses the internationalization (i18n) system to pull content from locale files that are managed through the CMS admin interface.

### Description of Task to be completed?

Task: Update AboutUsSection.jsx to dynamically fetch the intro section from CMS

Implementation Details:
Replaced static JSON data with useTranslation hook to fetch about.title and about.description
Added proper translations to all locale files (English, Norwegian, Malagasy)
Maintained fallback values to ensure content always displays
Preserved existing static data for non-intro sections
Ensured language switching triggers dynamic content updates

### How should this be manually tested?

**Run the project**
Run npm install to install dependencies
Start the development server with npm run dev
Navigate to the About page:
Verify the intro section displays with title "Let us introduce ourselves" and the full description

**Test language switching functionality:**
Locate the language selector on the page (typically in the navigation)
Switch between English, Norwegian, and Malagasy languages
Verify the intro section title and description change dynamically for each language:
English: "Let us introduce ourselves"
Norwegian: "La oss introdusere oss selv"
Malagasy: "Andao hifampitondra antsika"
Confirm no console errors appear during language switching

**Test CMS integration (if CMS is accessible):**

Navigate to /admin/
Edit the "About Us Page" section in the CMS
Modify the title or description fields
Save changes and verify they reflect immediately on the About page
Test fallback behavior:
Temporarily rename or modify locale files to simulate missing translations
Verify the component still displays content using fallback values
Restore locale files and confirm normal functionality returns
Verify no regressions:
Check that other sections on the About page still display correctly
Ensure the page layout and styling remain unchanged
Confirm the intro image still displays properly

### Any background context you want to provide?
The project uses Decap CMS with i18n support for content management. The existing AboutUsSection component was using static JSON data from about-us-page-content.json, which made content updates require code changes.
This update enables content editors to manage the intro section directly through the CMS interface while maintaining the existing design and functionality. The component now follows the same pattern used elsewhere in the application for CMS-driven content, ensuring consistency across the codebase.
The implementation maintains backward compatibility by keeping fallback values and preserving the existing static data for other sections that don't need CMS management yet.
